### PR TITLE
feat: allow to upgrade eth contracts

### DIFF
--- a/.openzeppelin/base-sepolia.json
+++ b/.openzeppelin/base-sepolia.json
@@ -1,0 +1,113 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x3EF0DE9f6032dFddfaCdd824E6c5D30d3A668e31"
+  },
+  "proxies": [
+    {
+      "address": "0xCCEe85F7ECEe486f89fB3F5597F569B2E539ec08",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "475ecfc437cce45e5ddff339eb251e48a842e576da6024e2049b4a5712a0b802": {
+      "address": "0xE4421770C0f14b0c796ed785c7777a708c176e17",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "ics20Proxy",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AlloOFTUpgradeable",
+            "src": "contracts/AlloOFTUpgradeable.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ERC20": [
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_balances",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:33"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_allowances",
+              "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:35"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_totalSupply",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:37"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:39"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_symbol",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xE4421770C0f14b0c796ed785c7777a708c176e17"
+      ]
+    }
+  }
+}

--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1,0 +1,110 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0xaCF57Fa027654c21EE63900910BB623D82bDc907"
+  },
+  "proxies": [
+    {
+      "address": "0x8408D45b61f5823298F19a09B53b7339c0280489",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "bfeda88e5db986ffd227e0569b68710a00d69db1be3c01b9d32275db9e712263": {
+      "address": "0xB21c7c5A7be430Ea3517892E63F905C109b06278",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "ics20Proxy",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AlloOFTUpgradeable",
+            "src": "contracts/AlloOFTUpgradeable.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ERC20": [
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_balances",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:33"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_allowances",
+              "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:35"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_totalSupply",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:37"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:39"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_symbol",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.openzeppelin/sepolia.json
+++ b/.openzeppelin/sepolia.json
@@ -1,0 +1,210 @@
+{
+  "manifestVersion": "3.2",
+  "admin": {
+    "address": "0x252EE10738E489C2c9d2D6e5F79341d0e2b5B632"
+  },
+  "proxies": [
+    {
+      "address": "0x2450255a81faF9bC743481B793867bA080dd9Dd9",
+      "kind": "transparent"
+    }
+  ],
+  "impls": {
+    "475ecfc437cce45e5ddff339eb251e48a842e576da6024e2049b4a5712a0b802": {
+      "address": "0xD2194DC9feE383Aa563b31edfbd7ee7A9F227D77",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "ics20Proxy",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AlloOFTUpgradeable",
+            "src": "contracts/AlloOFTUpgradeable.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ERC20": [
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_balances",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:33"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_allowances",
+              "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:35"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_totalSupply",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:37"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:39"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_symbol",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      },
+      "allAddresses": [
+        "0xD2194DC9feE383Aa563b31edfbd7ee7A9F227D77"
+      ]
+    },
+    "0999d70d63177cffdb370be83a3ce90259ecb355aac0552db8532f9c9c8233a8": {
+      "address": "0x80F04c97CaFAce7BB86862866a31DB653c1A35E8",
+      "txHash": "0x7504c85791237d565ef0ead5acad7dfab7a61d19f09e017f8bf1af9b176e892c",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "ics20Proxy",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_address",
+            "contract": "AlloOFTUpgradeableV2",
+            "src": "contracts/AlloOFTUpgradeableV2.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)"
+          },
+          "t_uint256": {
+            "label": "uint256"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(address => mapping(address => uint256))"
+          },
+          "t_string_storage": {
+            "label": "string"
+          },
+          "t_uint64": {
+            "label": "uint64"
+          },
+          "t_bool": {
+            "label": "bool"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.ERC20": [
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_balances",
+              "type": "t_mapping(t_address,t_uint256)",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:33"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_allowances",
+              "type": "t_mapping(t_address,t_mapping(t_address,t_uint256))",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:35"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_totalSupply",
+              "type": "t_uint256",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:37"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_name",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:39"
+            },
+            {
+              "contract": "ERC20Upgradeable",
+              "label": "_symbol",
+              "type": "t_string_storage",
+              "src": "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol:40"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Ownable": [
+            {
+              "contract": "OwnableUpgradeable",
+              "label": "_owner",
+              "type": "t_address",
+              "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:24"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:69"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:73"
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.prettierignore
+++ b/.prettierignore
@@ -13,4 +13,5 @@ out/
 package-lock.json
 package.json
 deployments
+.openzeppelin
 lib/**/*

--- a/README.md
+++ b/README.md
@@ -370,3 +370,79 @@ npx hardhat lz:ownable:transfer-ownership --oapp-config layerzero.config.ts
 
 The `transferOwnership` method on the `ProxyAdmin` must be called providing the new owner, this can be done on an
 explorer.
+
+### Solana
+
+The ownership of Solana programs can be achieved in the following steps:
+
+#### 1. Set Delegate:
+
+This step **must** be done before transferring the OFT ownership.
+
+On the concerned contract in [layerzero.config.ts](layerzero.config.ts), set the `delegate` field to the of the new
+delegate, e.g.:
+
+```
+{
+    contract: myContract,
+    config: {
+        delegate: '0x8330bcC0770bAb19Cd4AcEdb4DC4c0d9B3E9528E',
+    },
+}
+```
+
+To apply the changes run the wire command:
+
+```bash
+npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts
+```
+
+#### 2. Transfer OFT Ownership:
+
+On the concerned contract in [layerzero.config.ts](layerzero.config.ts), set the `owner` field to the of the new
+owner, e.g.:
+
+```
+{
+    contract: myContract,
+    config: {
+        delegate: '0x8330bcC0770bAb19Cd4AcEdb4DC4c0d9B3E9528E',
+        owner: '0x8330bcC0770bAb19Cd4AcEdb4DC4c0d9B3E9528E',
+    },
+}
+```
+
+To apply the changes run the following command:
+
+```bash
+npx hardhat lz:ownable:transfer-ownership --oapp-config layerzero.config.ts
+```
+
+#### 3. Update SPL metadata update authority
+
+The current SPL metadata can be fetched using the metaboss CLI:
+
+```bash
+metaboss -r https://api.devnet.solana.com decode mint --full -a <MINT_ADDR>
+cat <MINT_ADDR>.json
+```
+
+To change the update authority use:
+
+```bash
+npx hardhat lz:oft:solana:set-update-authority --eid 40168 --mint <MINT_ADDR> --new-update-authority <NEW_OWNER>
+```
+
+#### 4. Update OFT program upgrade authority
+
+We can get the current program upgrade authority with:
+
+```bash
+solana program show <PROGRAM_ID>
+```
+
+To update it:
+
+```bash
+solana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <NEW_OWNER> -k old-owner-keypair.json --skip-new-upgrade-authority-signer-check
+```

--- a/README.md
+++ b/README.md
@@ -446,3 +446,30 @@ To update it:
 ```bash
 solana program set-upgrade-authority <PROGRAM_ID> --new-upgrade-authority <NEW_OWNER> -k old-owner-keypair.json --skip-new-upgrade-authority-signer-check
 ```
+
+### Multisig
+
+When using multisigs, some commands (i.e. typically `lz:oapp:wire`) will require some arguments:
+
+- For EVM: the `--safe` option will make the task to use the configured safe config in `hardhat.config.ts`;
+- For Solana: the `--multisig-key` option will allow to set the squads multisig PDA;
+
+### Upgrade
+
+#### EVM
+
+To upgrade an EVM contract you can use the `lz:oft:evm:upgrade` task, using the following args:
+
+- `--eid`: The endpoint id of the targeted chain;
+- `--new-contract-name`: The name of the new contract to deploy;
+- `--safe`: If the contract owner is a multisig, this will only deploy the contract, another step will be required to
+  call the `upgrade` method on the contract ProxyAdmin using the multisig;
+
+For example:
+
+```bash
+npx hardhat lz:oft:evm:upgrade --eid 40161 --new-contract-name AlloOFTUpgradeableV2 --safe
+```
+
+After deploying or upgrade we must ensure that current deployments informations are up to date under `deployments` and
+`.openzeppelin` folders. The openzeppelin info can be generated using the task `lz:oft:evm:import-openzeppelin-network`.

--- a/README.md
+++ b/README.md
@@ -314,3 +314,59 @@ npx hardhat lz:oft:send --src-eid 40161 --dst-eid 40168 --amount 1 --to 97zzVFru
 # Send 1 ALLO from Solana to Ethereum Sepolia
 npx hardhat lz:oft:send --src-eid 40168 --dst-eid 40161 --amount 1 --to 0xF2489e0d20Df54514B371dF0360316B244a275c6
 ```
+
+## Transfer Ownership
+
+This section ought to describe how to transfer ownership of the different contracts, depending on the target network.
+
+### EVM
+
+The ownership of EVM contracts can be achieved in three steps:
+
+#### 1. Set Delegate:
+
+This step **must** be done before transferring the OFT ownership.
+
+On the concerned contract in [layerzero.config.ts](layerzero.config.ts), set the `delegate` field to the of the new
+delegate, e.g.:
+
+```
+{
+    contract: myContract,
+    config: {
+        delegate: '0x8330bcC0770bAb19Cd4AcEdb4DC4c0d9B3E9528E',
+    },
+}
+```
+
+To apply the changes run the wire command:
+
+```bash
+npx hardhat lz:oapp:wire --oapp-config layerzero.config.ts
+```
+
+#### 2. Transfer OFT Ownership:
+
+On the concerned contract in [layerzero.config.ts](layerzero.config.ts), set the `owner` field to the of the new
+owner, e.g.:
+
+```
+{
+    contract: myContract,
+    config: {
+        delegate: '0x8330bcC0770bAb19Cd4AcEdb4DC4c0d9B3E9528E',
+        owner: '0x8330bcC0770bAb19Cd4AcEdb4DC4c0d9B3E9528E',
+    },
+}
+```
+
+To apply the changes run the following command:
+
+```bash
+npx hardhat lz:ownable:transfer-ownership --oapp-config layerzero.config.ts
+```
+
+#### 3. Transfer ProxyAdmin Ownership:
+
+The `transferOwnership` method on the `ProxyAdmin` must be called providing the new owner, this can be done on an
+explorer.

--- a/tasks/evm/importOpenZeppelinNetwork.ts
+++ b/tasks/evm/importOpenZeppelinNetwork.ts
@@ -1,0 +1,42 @@
+import { task } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
+import { ChainType, endpointIdToChainType, endpointIdToNetwork } from '@layerzerolabs/lz-definitions'
+import { getDeploymentAddressAndAbi } from '@layerzerolabs/lz-evm-sdk-v2'
+
+import layerzeroConfig from '../../layerzero.config'
+import { DebugLogger, KnownErrors } from '../common/utils'
+
+task(
+    'lz:oft:evm:import-openzeppelin-network',
+    'Import the open zeppelin network.json file based on the current contract impl'
+).setAction(async (_, hre: HardhatRuntimeEnvironment) => {
+    const { contracts } = typeof layerzeroConfig === 'function' ? await layerzeroConfig() : layerzeroConfig
+    const getHreByEid = createGetHreByEid(hre)
+
+    for (const {
+        contract: { eid, contractName, address },
+    } of contracts) {
+        if (endpointIdToChainType(eid) !== ChainType.EVM) {
+            continue
+        }
+
+        let eidHre: HardhatRuntimeEnvironment
+        try {
+            eidHre = await getHreByEid(eid)
+        } catch (error) {
+            DebugLogger.printErrorAndFixSuggestion(
+                KnownErrors.ERROR_GETTING_HRE,
+                `For network: ${endpointIdToNetwork(eid)}`
+            )
+            throw error
+        }
+
+        const { address: lzEndpointAddr } = getDeploymentAddressAndAbi(endpointIdToNetwork(eid), 'EndpointV2')
+        const proxyAddress = contractName ? (await eidHre.deployments.get(contractName)).address : address!
+        const alloOFT = await eidHre.ethers.getContractFactory('AlloOFTUpgradeable')
+
+        await eidHre.upgrades.forceImport(proxyAddress, alloOFT, { constructorArgs: [lzEndpointAddr] })
+    }
+})

--- a/tasks/evm/upgradeContract.ts
+++ b/tasks/evm/upgradeContract.ts
@@ -1,0 +1,65 @@
+import { task, types } from 'hardhat/config'
+import { HardhatRuntimeEnvironment } from 'hardhat/types'
+
+import { createGetHreByEid } from '@layerzerolabs/devtools-evm-hardhat'
+import { ChainType, EndpointId, endpointIdToChainType, endpointIdToNetwork } from '@layerzerolabs/lz-definitions'
+import { getDeploymentAddressAndAbi } from '@layerzerolabs/lz-evm-sdk-v2'
+
+import layerzeroConfig from '../../layerzero.config'
+import { DebugLogger, KnownErrors } from '../common/utils'
+
+interface Args {
+    eid: EndpointId
+    newContractName: string
+    safe: boolean
+}
+
+task('lz:oft:evm:upgrade', 'Upgrades an OFT contract on EVM network')
+    .addParam('eid', 'Endpoint ID of the network to upgrade', undefined, types.int)
+    .addParam('newContractName', 'The name of the contract to upgrade to', undefined, types.string)
+    .addFlag(
+        'safe',
+        'If specified: only deploy the implementation, the proxy will need to be upgraded through the gnosis safe'
+    )
+    .setAction(async ({ eid, newContractName, safe }: Args, hre: HardhatRuntimeEnvironment) => {
+        if (endpointIdToChainType(eid) !== ChainType.EVM) {
+            throw new Error(`non-EVM eid (${eid}) not supported here`)
+        }
+
+        const getHreByEid = createGetHreByEid(hre)
+        let eidHre: HardhatRuntimeEnvironment
+        try {
+            eidHre = await getHreByEid(eid)
+        } catch (error) {
+            DebugLogger.printErrorAndFixSuggestion(
+                KnownErrors.ERROR_GETTING_HRE,
+                `For network: ${endpointIdToNetwork(eid)}`
+            )
+            throw error
+        }
+
+        const { contracts } = typeof layerzeroConfig === 'function' ? await layerzeroConfig() : layerzeroConfig
+        const proxy = contracts.find((c) => c.contract.eid === eid)
+
+        if (!proxy) throw new Error(`No config for EID ${eid}`)
+        const proxyAddress = proxy.contract.contractName
+            ? (await eidHre.deployments.get(proxy.contract.contractName)).address
+            : proxy.contract.address!
+
+        const newOFT = await eidHre.ethers.getContractFactory(newContractName)
+
+        const { address: lzEndpointAddr } = getDeploymentAddressAndAbi(endpointIdToNetwork(eid), 'EndpointV2')
+
+        if (safe) {
+            const resp = await eidHre.upgrades.prepareUpgrade(proxyAddress, newOFT, {
+                kind: 'transparent',
+                constructorArgs: [lzEndpointAddr],
+                unsafeAllow: ['constructor', 'state-variable-immutable', 'missing-initializer-call'],
+            })
+
+            console.log(`Prepared upgrade for ${newContractName} at ${proxyAddress}. New contract addr: ${resp}`)
+        } else {
+            const resp = await eidHre.upgrades.upgradeProxy(proxyAddress, newOFT)
+            console.log(`Proxy upgraded for ${newContractName} at ${proxyAddress}. New contract addr: ${resp}`)
+        }
+    })

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -1,6 +1,8 @@
 import './common/config.get'
 import './common/wire'
 import './common/sendOFT'
+import './evm/upgradeContract'
+import './evm/importOpenZeppelinNetwork'
 import './solana/initConfig'
 import './solana/createOFT'
 import './solana/createOFTAdapter'


### PR DESCRIPTION
This PR brings necessary elements to upgrade EVM contracts.

## Details

Some hardhat tasks detailed below have been added to help the upgrade process, however some manual tasks are still needed.

The readme has been updated to cover the upgrade process, as well as the ownership transfer and the usage of multisigs as contract owner.

### New Tasks

#### `lz:oft:evm:import-openzeppelin-network`

This task help to generate the currently deployed contracts storage layout in `.openzeppelin`, this must be run with the code matching the deployed contracts, the generated elements are used during the upgrade to ensure the new contract storage layout is compatible.

#### `lz:oft:evm:upgrade`

This task will deploy the new contract implementation, and if the signer is the owner it'll also upgrade the proxy contract to use the new implementation.

If the contract's owner is a gnosis safe, a secondary step will be needed to call the `upgrade` method of the proxy admin contract using the multisig.